### PR TITLE
INSTRM-2956: add thetaPhiScan takeNextPhi command

### DIFF
--- a/python/ics/iicActor/Commands/MiscCmd.py
+++ b/python/ics/iicActor/Commands/MiscCmd.py
@@ -39,6 +39,8 @@ class MiscCmd(object):
             ('thetaPhiScan', 'start', self.startNewThetaPhiScan),
             ('thetaPhiScan', f'takeNextTheta [<groupId>] [<thetaAngle>] [<exptime>] {identArgs} {translate.seqArgs}',
              self.takeNextThetaPhiScan),
+            ('thetaPhiScan', f'takeNextPhi [<groupId>] [<phiAngle>] [<exptime>] {identArgs} {translate.seqArgs}',
+             self.takeNextPhiThetaScan),
             ('declareHomeDesign', '[@skipGenVisit0]', self.declareHomeDesign)
         ]
 
@@ -71,6 +73,8 @@ class MiscCmd(object):
                                         keys.Key('mode', types.String() * (1,), help='mode for dotRoach'),
                                         keys.Key("thetaAngle", types.Int(), units='deg',
                                                  help="Designed theta angle (deg)"),
+                                        keys.Key("phiAngle", types.Int(), units='deg',
+                                                 help="Designed phi angle (deg)"),
                                         )
 
     @property
@@ -177,16 +181,16 @@ class MiscCmd(object):
 
     @singleShot
     def takeNextThetaPhiScan(self, cmd):
-        """"""
+        self._thetaPhiScan(cmd, constantAxis='theta')
 
-        def getRemainingThetas(groupId):
-            scannedThetas = self.engine.opdb.getScannedThetaFromThetaPhiScanId(groupId, phiAngles=phiAngles)
-            remainingThetas = list(set(thetaAngles) - set(scannedThetas))
-            remainingThetas.sort()
-            return remainingThetas
+    @singleShot
+    def takeNextPhiThetaScan(self, cmd):
+        self._thetaPhiScan(cmd, constantAxis='phi')
+
+    def _thetaPhiScan(self, cmd, constantAxis):
+        innerAxis = 'phi' if constantAxis == 'theta' else 'theta'
 
         def bailIfNotFinished(seq, label):
-            """Return True iff the sub-sequence finished cleanly; otherwise cmd.fail and abort the scan."""
             if seq.status.flag == Flag.FINISHED:
                 return True
             if cmd.alive:
@@ -194,8 +198,9 @@ class MiscCmd(object):
             return False
 
         cmdKeys = cmd.cmd.keywords
+        constantAngleKey = f'{constantAxis}Angle'
+        constantAngle = cmdKeys[constantAngleKey].values[0] if constantAngleKey in cmdKeys else None
         groupId = cmdKeys['groupId'].values[0] if 'groupId' in cmdKeys else None
-        thetaAngle = cmdKeys['thetaAngle'].values[0] if 'thetaAngle' in cmdKeys else None
 
         mcsExptime = self.actor.actorConfig['mcs']['exptime']
         illuminators = self.actor.actorConfig['illuminators']
@@ -204,32 +209,50 @@ class MiscCmd(object):
         moveToPfsDesignConfig = thetaPhiScanConfig['moveToPfsDesign']
         phiAngles = thetaPhiScanConfig['phiAngles']
         thetaAngles = thetaPhiScanConfig['thetaAngles']
+        scanPhiHome = thetaPhiScanConfig['scanPhiHome']
+        scanThetaHome = thetaPhiScanConfig['scanThetaHome']
+
+        constantAngles = thetaAngles if constantAxis == 'theta' else phiAngles
+        scanAngles  = phiAngles if constantAxis == 'theta' else thetaAngles
+        scanInnerHome = scanPhiHome if constantAxis == 'theta' else scanThetaHome
+
+        if scanInnerHome:
+            scanAngles = [scanAngles[0], 0] + scanAngles[1:]
+
+        def getRemainingAngles(groupId):
+            if constantAxis == 'theta':
+                scanned = self.engine.opdb.getScannedThetaFromThetaPhiScanId(groupId, phiAngles=scanAngles)
+            else:
+                scanned = self.engine.opdb.getScannedPhiFromThetaPhiScanId(groupId, thetaAngles=scanAngles)
+            remaining = list(set(constantAngles) - set(scanned))
+            remaining.sort()
+            return remaining
 
         if groupId is None:
             groupId = self.engine.opdb.latestThetaPhiScanId()
 
         try:
-            remainingThetas = getRemainingThetas(groupId)
-            cmd.inform(
-                f'text="ThetaPhiScan groupId={groupId} remaining thetaAngles: {",".join(map(str, remainingThetas))}"')
+            remainingAngles = getRemainingAngles(groupId)
+            cmd.inform(f'text="thetaPhiScan groupId={groupId} remaining {constantAxis}Angles: '
+                       f'{",".join(map(str, remainingAngles))}"')
         except Exception as e:
             cmd.warn(f'text="{str(e)}"')
-            remainingThetas = None
+            remainingAngles = None
 
-        if thetaAngle is None:
-            if remainingThetas is None:
-                cmd.fail(f'text="cannot determine remaining theta angles for groupId={groupId}; '
-                         f'pass thetaAngle=<deg> explicitly"')
+        if constantAngle is None:
+            if remainingAngles is None:
+                cmd.fail(f'text="cannot determine remaining {constantAxis} angles for groupId={groupId}; '
+                         f'pass {constantAxis}Angle=<deg> explicitly"')
                 return
-            elif len(remainingThetas) == 0:
-                cmd.finish(f'text="ThetaPhiScan groupId={groupId} already covers all configured theta angles '
-                           f'({",".join(map(str, thetaAngles))}); no further scan needed"')
+            elif len(remainingAngles) == 0:
+                cmd.finish(f'text="thetaPhiScan groupId={groupId} already covers all configured {constantAxis} angles '
+                           f'({",".join(map(str, constantAngles))}); no further scan needed"')
                 return
-            thetaAngle = remainingThetas[0]
+            constantAngle = remainingAngles[0]
 
-        cmd.inform(f'text="ThetaPhiScan groupId={groupId} thetaAngle={thetaAngle:d} deg START"')
+        cmd.inform(f'text="thetaPhiScan groupId={groupId} {constantAxis}Angle={constantAngle:d} deg START"')
 
-        name = f'theta_{thetaAngle:03d}'
+        name = f'{constantAxis}_{constantAngle:03d}'
         lampsKeys = dict(halogen=int(translate.resolveExptime(cmdKeys, scienceTraceConfig)))
         __, duplicate = translate.spsExposureKeys(cmdKeys, doRaise=False)
         windowKeys = translate.windowKeys(cmdKeys, scienceTraceConfig)
@@ -249,13 +272,14 @@ class MiscCmd(object):
         if not bailIfNotFinished(scienceTrace, 'cobraHome scienceTrace'):
             return
 
-        for phiAngle in phiAngles:
-            designName = f'thetaPhiScan_{thetaAngle:03d}_{phiAngle:03d}'
+        for innerAngle in scanAngles:
+            thetaAngle, phiAngle = (constantAngle, innerAngle) if constantAxis == 'theta' else (innerAngle, constantAngle)
+            designName = f'thetaPhiScan_{constantAngle:03d}_{innerAngle:03d}'
 
-            # going to phi home
-            if phiAngle == 0:
-                designId = self._runFpsCreateDesign(f'createHomeDesign phi designName={designName}')
-                moveCobra = fpsSequenceList.MoveToHome(designId=designId, exptime=mcsExptime, phi=True, **illuminators)
+            if innerAngle == 0:
+                designId = self._runFpsCreateDesign(f'createHomeDesign {innerAxis} designName={designName}')
+                moveCobra = fpsSequenceList.MoveToHome(designId=designId, exptime=mcsExptime,
+                                                       **{innerAxis: True}, **illuminators)
             else:
                 designId = self._runFpsCreateDesign(
                     f'createThetaPhiScanDesign thetaAngle={thetaAngle:d} phiAngle={phiAngle:d} designName={designName}')
@@ -273,14 +297,14 @@ class MiscCmd(object):
             self.engine.run(cmd, scienceTrace, doFinish=False)
             if not bailIfNotFinished(scienceTrace, f'{designName} scienceTrace'):
                 return
-            cmd.inform(
-                f'text="ThetaPhiScan groupId={groupId} thetaAngle={thetaAngle:d} deg phiAngle={phiAngle:d} deg DONE"')
+            cmd.inform(f'text="thetaPhiScan groupId={groupId} {constantAxis}Angle={constantAngle:d} deg '
+                       f'{innerAxis}Angle={innerAngle:d} deg DONE"')
 
-        cmd.inform(f'text="ThetaPhiScan groupId={groupId} thetaAngle={thetaAngle:d} deg FINISHED"')
-        remainingThetas = getRemainingThetas(groupId)
-        cmd.inform(
-            f'text="ThetaPhiScan groupId={groupId} remaining thetaAngles: {",".join(map(str, remainingThetas))}"')
-        cmd.finish(f'nRemainingThetas={len(remainingThetas)}')
+        cmd.inform(f'text="thetaPhiScan groupId={groupId} {constantAxis}Angle={constantAngle:d} deg FINISHED"')
+        remainingAngles = getRemainingAngles(groupId)
+        cmd.inform(f'text="thetaPhiScan groupId={groupId} remaining {constantAxis}Angles: '
+                   f'{",".join(map(str, remainingAngles))}"')
+        cmd.finish(f'nRemaining{constantAxis.capitalize()}s={len(remainingAngles)}')
 
     def declareHomeDesign(self, cmd, doFinish=True, genVisit0=True):
         """Create a fresh home design and declare it as the current FPS design."""

--- a/python/ics/iicActor/utils/opdb.py
+++ b/python/ics/iicActor/utils/opdb.py
@@ -215,19 +215,8 @@ class OpdbHandler:
         sql = f"""select max(group_id) from sequence_group where group_name='{groupName}'"""
         return self.fetchone(sql)
 
-    def getScannedThetaFromThetaPhiScanId(self, groupId, phiAngles):
-        """Return theta angles fully scanned under this groupId.
-
-        takeNextThetaPhiScan(thetaAngle=N) writes one scienceTrace row per
-        sub-config under name=f'theta_{N:03d}' with distinct comments
-        ('cobraHome' for the home pose, then 'thetaPhiScan_{N:03d}_{phi:03d}'
-        for each configured phi). A theta is considered scanned only when
-        every expected comment is present AND the underlying sequence
-        finished successfully -- so a partial/crashed run, or a stale-phi
-        run from a previous configuration, both stay in the remaining list.
-        Misgrouped rows (wrong sequence_type or non-theta name) are
-        ignored.
-        """
+    def _fetchScienceTracesByGroup(self, groupId):
+        """Return finished scienceTrace rows for a groupId."""
         sql = (f'select iic_sequence.name, iic_sequence.comments '
                f'from iic_sequence '
                f'inner join iic_sequence_status '
@@ -235,17 +224,23 @@ class OpdbHandler:
                f'where iic_sequence.group_id={groupId} '
                f"and iic_sequence.sequence_type='scienceTrace' "
                f'and iic_sequence_status.status_flag={Flag.FINISHED}')
-        df = self.fetch(sql)
-        # enforce the exact name pattern produced by takeNextThetaPhiScan,
-        # i.e. 'theta_NNN' with a 3-digit zero-padded angle. This rejects
-        # legacy/foreign names like 'theta_scan_radius1.0_angle15' that would
-        # otherwise blow up the int() parse below.
-        df = df[df.name.str.fullmatch(r'theta_\d{3}')]
-        df['theta'] = [int(name.split('_')[1]) for name in df.name]
+        return self.fetch(sql)
+
+    def _getScannedAngles(self, groupId, constantAxis, scanAngles):
+        """Return outer angles fully scanned (all scanAngles present and finished) under this groupId."""
+        df = self._fetchScienceTracesByGroup(groupId)
+        df = df[df.name.str.fullmatch(rf'{constantAxis}_\d{{3}}')]
+        df[constantAxis] = [int(name.split('_')[1]) for name in df.name]
 
         scanned = []
-        for theta, group in df.groupby('theta'):
-            expected = {'cobraHome'} | {f'thetaPhiScan_{theta:03d}_{phi:03d}' for phi in phiAngles}
+        for constantAngle, group in df.groupby(constantAxis):
+            expected = {'cobraHome'} | {f'thetaPhiScan_{constantAngle:03d}_{inner:03d}' for inner in scanAngles}
             if expected.issubset(set(group.comments)):
-                scanned.append(int(theta))
+                scanned.append(int(constantAngle))
         return scanned
+
+    def getScannedThetaFromThetaPhiScanId(self, groupId, phiAngles):
+        return self._getScannedAngles(groupId, 'theta', phiAngles)
+
+    def getScannedPhiFromThetaPhiScanId(self, groupId, thetaAngles):
+        return self._getScannedAngles(groupId, 'phi', thetaAngles)


### PR DESCRIPTION
Factorize takeNextThetaPhiScan and the new takeNextPhiThetaScan into a shared _thetaPhiScan(cmd, constantAxis) implementation. Both commands share the same thetaPhiScan config section, group, and comment prefix; the iic_sequence name (theta_NNN vs phi_NNN) disambiguates the constant axis. The scanPhiHome/scanThetaHome config flags insert a home step at position 1 of the scan angle list, dispatching to createHomeDesign + MoveToHome when scanAngle==0. opdb gains _getScannedAngles and getScannedPhiFromThetaPhiScanId to track phi-scan completion.